### PR TITLE
Feature/buildnumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Currently, Baumeister is in statu nascendi and merely useful. While moving
 from release 0.1.0 towards 1.0.0 this will change...
 
 ## Next TODOs
-* [ ] Define a human readable build identifier (i.e. counting up) for each jobs
+* [x] Define a human readable build identifier (i.e. counting up) for each jobs
 * [x] Attach the project name to each build job
 * [ ] Define a consistent event structure including a rendering function for HTML/JSON
 * [ ] Store build results in the Mnesia DB

--- a/apps/baumeister_core/lib/coordinator.ex
+++ b/apps/baumeister_core/lib/coordinator.ex
@@ -110,8 +110,9 @@ defmodule Baumeister.Coordinator do
   worker is found, the error `unsupported_feature` is returned and the
   job is neither executed nor enqueued for later execution.
   """
-  @spec add_job(Coordinate.t, BaumeisterFile.t) :: {:ok, reference} | {:unsupported_feature, any}
-  def add_job(coordinate, bmf) do
+  @spec add_job(Coordinate.t, BaumeisterFile.t, pos_integer) :: {:ok, reference} | {:unsupported_feature, any}
+  def add_job(coordinate, bmf, build_number \\ 1) do
+    Logger.error "Ignoring build number #{build_number}"
     GenServer.call(name(), {:add_job, coordinate, bmf})
   end
 

--- a/apps/baumeister_core/test/baumeister_test.exs
+++ b/apps/baumeister_core/test/baumeister_test.exs
@@ -58,7 +58,7 @@ defmodule BaumeisterTest do
 
     TestListener.clear(listener)
     assert :ok == Baumeister.add_project(project_name, url,
-      [{NoopPlugin, {url, bmf}}, {Delay, 50}, {Take, 2}])
+      [{NoopPlugin, {url, bmf}}, {Delay, 50}, {Take, 1}])
     assert true == Baumeister.enable(project_name)
 
     # wait for first execution

--- a/apps/baumeister_core/test/baumeister_test.exs
+++ b/apps/baumeister_core/test/baumeister_test.exs
@@ -64,7 +64,7 @@ defmodule BaumeisterTest do
     # wait for first execution
     Utils.wait_for(fn -> listener
       |> TestListener.get()
-      |> Enum.any?(fn {w, _, data} -> w == :worker and match?({:ok, _}, data) end)
+      |> Enum.any?(fn {w, _, data} -> w == :worker and match?({:log, _, _}, data) end)
     end)
     Baumeister.disable(project_name)
 

--- a/apps/baumeister_core/test/baumeister_test.exs
+++ b/apps/baumeister_core/test/baumeister_test.exs
@@ -1,6 +1,96 @@
 defmodule BaumeisterTest do
+  require Logger
   use ExUnit.Case
+
+  alias Baumeister.Test.TestListener
+  alias Baumeister.Test.Utils
+  alias Experimental.GenStage
+  alias Baumeister.EventCenter
+  alias Baumeister.Worker
+  alias Baumeister.Observer.Take
+  alias Baumeister.Observer.NoopPlugin
+  alias Baumeister.Observer.Delay
+
   doctest Baumeister
   doctest Baumeister.BaumeisterFile
+
+  setup context do
+    Logger.info("setup: context = #{inspect context}")
+    sup_name = Baumeister.Supervisor
+    opts = [strategy: :one_for_one, name: sup_name]
+    children = Baumeister.App.setup_coordinator()
+    Logger.info "ObserverTest.setup: Stopping Supervisor"
+    if GenServer.whereis(sup_name) != nil, do: :ok = Supervisor.stop(sup_name)
+    assert assert_down(sup_name)
+
+    Logger.info "ObserverTest.setup: (Re)starting Supervisor"
+    {:ok, sup_pid} = Supervisor.start_link(children, opts)
+    counts = Supervisor.count_children(sup_pid)
+    assert counts[:specs] == counts[:active]
+
+    # need process flag, because Observer will crash
+    # Process.flag(:trap_exit, true)
+    {:ok, listener} = TestListener.start()
+    Utils.wait_for fn -> GenServer.whereis(EventCenter.name()) != nil end
+    GenStage.sync_subscribe(listener, to: EventCenter.name())
+
+    # Let the listener drain the event queue of old events.
+    Utils.wait_for fn -> 0 == EventCenter.clear() end
+
+    on_exit(fn ->
+      Enum.each([listener, EventCenter.name(), sup_pid],
+        fn p -> assert_down(p) end)
+    end)
+    # merge this with the context
+    [listener: listener]
+  end
+
+
+  @tag timeout: 1_000
+  test "observer and buildmaster run together", context do
+    listener = context[:listener]
+    project_name = context[:test] |> Atom.to_string()
+    {bmf, _os} = Utils.create_bmf """
+    echo "Ja, wir schaffen das"
+    """
+    url = "file:///"
+    {:ok, worker} = Worker.start_link()
+
+    TestListener.clear(listener)
+    assert :ok == Baumeister.add_project(project_name, url,
+      [{NoopPlugin, {url, bmf}}, {Delay, 50}, {Take, 2}])
+    assert true == Baumeister.enable(project_name)
+
+    # wait for first execution
+    Utils.wait_for(fn -> listener
+      |> TestListener.get()
+      |> Enum.any?(fn {w, _, data} -> w == :worker and match?({:ok, _}, data) end)
+    end)
+    Baumeister.disable(project_name)
+
+    # consider only worker messages
+    l = listener
+    |> TestListener.get()
+    |> Enum.filter(fn {w, a, _} -> w == :worker and a == :execute end)
+    |> Enum.map(fn {_, _, data} -> data end)
+
+    assert [{:start, coord}, {:ok, coord}, {:log, coord, "Ja, wir schaffen das\n"}] = l
+    Process.exit(worker, :normal)
+    assert assert_down(worker)
+  end
+
+  # asserts that the given process is down with 100 ms
+  defp assert_down(pid) when is_pid(pid) do
+    Logger.debug "assert_down of #{inspect pid}"
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, _, _, _}
+  end
+  defp assert_down(process) do
+    Logger.debug "assert_down of #{inspect process}"
+    case GenServer.whereis(process) do
+      p when is_pid(p) -> assert_down(p)
+      nil -> Logger.debug "already unnamed: #{inspect process}"
+    end
+  end
 
 end

--- a/apps/baumeister_core/test/baumeister_test.exs
+++ b/apps/baumeister_core/test/baumeister_test.exs
@@ -45,11 +45,10 @@ defmodule BaumeisterTest do
     [listener: listener]
   end
 
-
   @tag timeout: 1_000
   test "observer and buildmaster run together", context do
     listener = context[:listener]
-    project_name = context[:test] |> Atom.to_string()
+    project_name = Atom.to_string(context[:test])
     {bmf, _os} = Utils.create_bmf """
     echo "Ja, wir schaffen das"
     """

--- a/apps/baumeister_core/test/observer_test.exs
+++ b/apps/baumeister_core/test/observer_test.exs
@@ -180,7 +180,7 @@ defmodule Baumeister.ObserverTest do
     pid = context[:pid]
     listener = context[:listener]
     project_name = context[:test] |> Atom.to_string()
-    bmf = Utils.create_bmf """
+    {bmf, _os} = Utils.create_bmf """
     command: echo "Ja, wir schaffen das"
     """
     url = "file:///"

--- a/apps/baumeister_core/test/observer_test.exs
+++ b/apps/baumeister_core/test/observer_test.exs
@@ -172,9 +172,8 @@ defmodule Baumeister.ObserverTest do
     [{_who, ev, coord}] = l
     IO.puts "#{inspect l}"
     assert %Coordinate{} = coord
-    assert coord.project_name == context[:test] |> Atom.to_string()
+    assert coord.project_name == Atom.to_string(context[:test])
   end
-
 
   defp log_inspect(value, level \\ :info) do
     apply(Logger, :bare_log, [level, "#{inspect value}"])


### PR DESCRIPTION
Each build run increments the build counter of the project. 
Currently it is ignored by the worker processes, but to handle this is the job of a better event logging mechanism in one of the next PRs.